### PR TITLE
Move commands to pre-steps

### DIFF
--- a/src/examples/full-diagnostic.yml
+++ b/src/examples/full-diagnostic.yml
@@ -30,10 +30,11 @@ usage:
     build-and-deploy:
       jobs:
         - build:
-            post-steps:
+            pre-steps:
               - diagnostic-orb/env-info
               - diagnostic-orb/memory
               - diagnostic-orb/test-results
+            post-steps:
               - diagnostic-orb/store-report
 
         - deploy:


### PR DESCRIPTION
These should run at the start of a job. Such as the memory command which runs the duration of a job lifecycle. Then the store-report will collect everything at the end as a post-step.